### PR TITLE
fix: stop using export default in index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ const semanticReleaseMajorTag = {
   success,
 };
 
-export default semanticReleaseMajorTag;
+export = semanticReleaseMajorTag;


### PR DESCRIPTION
Hi! Thank you for this plugin, it's really useful :) 

But I found a bug which prevents it from working - `semantic-release` never loads it

`export default` cannot be used because TS compiles it to `exports.default` which is not compatible with semantic-release

After this change it will be compiled to `module.exports = semanticReleaseMajorTag` which works

I tested locally and it finally loaded the plugin
```
[semantic-release] › ✔  Loaded plugin "success" from "semantic-release-major-tag"
```