### PR TITLE
fix: do not publish major tags for prereleases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  pull_request:
   push:
     branches:
       - '**'

--- a/src/steps/success.test.ts
+++ b/src/steps/success.test.ts
@@ -7,6 +7,10 @@ jest.mock('node:child_process', () => ({
   execSync: jest.fn(),
 }));
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('success', () => {
   it('should execute proper commands for basic major tag', () => {
     const repoUrlMock =
@@ -84,5 +88,27 @@ describe('success', () => {
     expect(() => success({ customTags: [true, false] }, contextMock)).toThrow(
       'customTags setting does not contain strings in array! customTags: true,false'
     );
+  });
+
+  it('should not create tags for prereleases', () => {
+    const repoUrlMock =
+      'https://test-user:test-credentials@example.com/my-test-repo.git';
+    const contextMock = {
+      options: {
+        repositoryUrl: repoUrlMock,
+      },
+      nextRelease: {
+        version: '2.1.3-beta.1',
+      },
+      branch: {
+        prerelease: 'beta',
+      },
+      logger: { info: jest.fn(), error: jest.fn() },
+    } as unknown as Context;
+    success(
+      { customTags: ['v${major}-test', 'v${major}.${minor}'] },
+      contextMock
+    );
+    expect(execSync).not.toBeCalled();
   });
 });

--- a/src/steps/success.ts
+++ b/src/steps/success.ts
@@ -1,11 +1,18 @@
-import type { Context } from 'semantic-release';
+import type { BranchObject, Context } from 'semantic-release';
 import { execSync } from 'node:child_process';
 
 import prepareTags from './prepareTags';
 import type { PluginConfigType } from './types';
 
+const isPrerelease = (branchObject: BranchObject) =>
+  branchObject && !!branchObject.prerelease;
+
 const success = (pluginConfig: PluginConfigType, context: Context) => {
-  const { options, nextRelease, logger } = context;
+  const { options, nextRelease, logger, branch } = context;
+  if (isPrerelease(branch)) {
+    logger.info(`Not publishing any tags on a prerelease!`);
+    return;
+  }
   if (!options) {
     logger.error(`Missing options from context!`);
     return;


### PR DESCRIPTION
Context
-------

I faced a bug in a program that parses tags created by
semantic-release-major-tag[^1] because I had the assumption that
prereleases would never be identified with a major tag.

This seems like the correct behavior, because prereleases exist to
allow developers to iterate on unstable changes without breaking the
stability guarantee of stable releases.

This commit adds a short-circuit to avoid publishing any major tags
if the release is marked as a prerelease.

Implementation
--------------

I'm not as confident as I could be that this change will function as
intended, because the semantic-release docs are all over the place.
This implementation is guided by the @types/semantic-release@17
documentation (which is the same as the latest version, v20):

```typescript
/**
 * The pre-release identifier to append to [semantic versions](https://semver.org/)
 * released from this branch.
 *
 * A `prerelease` property applies only to pre-release branches and
 * the `prerelease` value must be valid per the [Semantic Versioning
 * Specification](https://semver.org/#spec-item-9). It will determine
 * the name of versions. For example if `prerelease` is set to
 * `"beta"`, the version will be formatted like `2.0.0-beta.1`,
 * `2.0.0-beta.2`, etc.
 *
 * The value of `prerelease`, if defined as a string, is generated with
 * [Lodash template](https://lodash.com/docs#template) with the
 * variable `name` set to the name of the branch.
 *
 * If the `prerelease property is set to `true` then the name of the
 * branch is used as the pre-release identifier.
 *
 * Required for pre-release branches.
 */
prerelease?: string | boolean | undefined;
```

So, this code considers the `nextRelease` to be a prerelease if the
`context.branch.prerelease` value is not `undefined` or `false`. This is
notably different than "falsy", since "falsy" includes the empty string.

Alternative
-----------

An alternate implementation I chose not to implement considers the
`context.branch.type` value, as the semantic-release codebase does[^2].

I am wary of using this value (probably more than I should be) because
it is not present in @types/semantic-release at this location. Instead,
the types suggest it is present under `context.nextRelease.type`.

Though the value probably exists in both places, I'm doubly confused by
the typing of this value:

```typescript
/**
 * A semver release type.
 * See https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-types.js
 */
type ReleaseType = 'prerelease' | 'prepatch' | 'patch' | 'preminor' | 'minor' | 'premajor' | 'major';
```

I can imagine what a `prerelease` is, but when should I expect a
`prepatch`, `preminor`, or `premajor` version? I have no idea how to
mentally model these choices, and the linked url sheds no light on the
matter.

As a final confusion, the @semantic-release/github plugin also checks
for a `release` value[^3], which is not listed here.

Risk mitigation
---------------

To mitigate the risk of shipping this code without tests, note that the
implementation is likely to default to the current behavior if we're
checking the wrong type: `branchObject.prerelease` will be `undefined`
so we will consider no release to be a prerelease, and major tags will
always be pushed.

[^1]: https://github.com/EricCrosson/install-github-release-binary/commit/a277d430dae9b0429beca6c229c7454671fe07b5
[^2]: https://github.com/semantic-release/semantic-release/blob/1beeb84c9032a22d455fc21b9a736efbcfde6b5d/index.js#L186
[^3]: https://github.com/semantic-release/github/blob/5d1f65e0838d6825fdc006a11b419ce2e6eaf43d/lib/is-prerelease.js#L1